### PR TITLE
Add an explicit setuptools build-dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ black = { version = "^19.3b0", python = "^3.8" }
 pre-commit = "^1.18.2"
 
 [build-system]
-requires = ["poetry>=1.0.0b1"]
+requires = ["poetry>=1.0.0b1", "setuptools"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Poetry uses setuptools internally during build in some cases, such as when a build script is used. Modern pip uses PEP 517 build interface with isolated builds, and [does not](https://pip.pypa.io/en/stable/reference/pip/#setuptools-injection) automatically add setuptools to the build environment.

This leads to the following error when installing by modern pip from an sdist:
```
Collecting awaitwhat
  Using cached awaitwhat-20.1.tar.gz (8.8 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Building wheels for collected packages: awaitwhat
  Building wheel for awaitwhat (PEP 517) ... error
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3 /usr/lib64/python3.7/site-packages/pip/_vendor/pep517/_in_process.py build_wheel /tmp/tmpkk8nwa9s
       cwd: /tmp/pip-install-qmou7x43/awaitwhat
  Complete output (24 lines):
  Traceback (most recent call last):
    File "setup.py", line 2, in <module>
      from setuptools import setup
  ModuleNotFoundError: No module named 'setuptools'
  <skipped>
```